### PR TITLE
maximize img with in ideas overview - related issue: https://trello.c…

### DIFF
--- a/src/resources/idea/list.jsx
+++ b/src/resources/idea/list.jsx
@@ -253,7 +253,7 @@ export const IdeaList = (props) => {
       >
         <Datagrid>
           <TextField source="id"/>
-          <ImageField source="extraData.images[0]" label="Image"/>
+          <ImageField source="extraData.images[0]" label="Image" style={{ 'max-width': '200px', overflow: 'hidden' }}/>
           <TextField source="title"/>
           <TextField source="status"/>
           <TextField source="yes"/>


### PR DESCRIPTION
# Description

Maximize the width of images in ideas overview. Images were maximized in height only, and a braod uploaded image could take too much space.

## Issue reference

Fixes https://trello.com/c/7vQHYGDW

## Type of change

Interface improvement

## Documentation

N/A

## Tests

Locally