### PR TITLE
fix: check if fields exists before iterating over it

### DIFF
--- a/src/utils/export.jsx
+++ b/src/utils/export.jsx
@@ -9,7 +9,7 @@ export function exporter({ rows, fields, filename = 'data', type = 'csv' }) {
 
   rows = [...rows];
 
-  fields = [...fields] || Object.keys( rows[0] );
+  fields = fields ? [...fields] :  Object.keys( rows[0] );
   let index = fields.indexOf('site'); // 'site' may be included in the object, but should generally not be included in the export
   if (index > -1) fields.splice(index, 1);
   index = fields.indexOf('can'); // 'can' may be included in the object, but should never be included in the export


### PR DESCRIPTION
Fixes "Server communication error" errors when `fields` prop is undefined (it can't iterate over `undefined`)

```
react_devtools_backend.js:4026 TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at index.js:2:1744289
    at pC (index.js:2:1744351)
    at mC (export.jsx:12:12)
    at exporter (export.jsx:94:27)
    at ExportButton.js:48:17
```