### PR TITLE
Feature/download ideas as pdfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "filepond-plugin-image-preview": "^4.6.1",
     "material-ui-icons": "^1.0.0-beta.36",
     "papaparse": "^5.2.0",
+    "pdfmake": "^0.2.5",
     "ra-core": "^3.14.4",
     "ra-language-english": "^3.14.4",
     "react": "^16.13.1",

--- a/src/resources/idea/list.jsx
+++ b/src/resources/idea/list.jsx
@@ -259,6 +259,7 @@ export const IdeaList = (props) => {
           <TextField source="yes"/>
           <TextField source="no"/>
           <DateField source="createdAt"/>
+          <DateField source="publishedDate"/>
           <EditButton basePath="/idea"/>
         </Datagrid>
       </List>

--- a/src/resources/idea/list.jsx
+++ b/src/resources/idea/list.jsx
@@ -276,7 +276,7 @@ export const IdeaList = (props) => {
           <TextField source="yes"/>
           <TextField source="no"/>
           <DateField source="createdAt"/>
-          <DateField source="publishedDate"/>
+          <DateField source="publishDate"/>
           <EditButton basePath="/idea"/>
         </Datagrid>
       </List>

--- a/src/resources/idea/list.jsx
+++ b/src/resources/idea/list.jsx
@@ -27,6 +27,10 @@ import {CustomList as List} from '../../components/CustomList/index.jsx';
 import { parseRowsForExport } from '../../utils/export.jsx';
 
 import XLSX from 'xlsx';
+import pdfMake from "pdfmake/build/pdfmake";
+import pdfFonts from "pdfmake/build/vfs_fonts";
+import PdfDocDefinition from './pdf-doc-definition.jsx';
+pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
 const IdeaPagination = props => <Pagination rowsPerPageOptions={[10, 25, 50, 100]} {...props} />;
 
@@ -89,7 +93,11 @@ const exporter = ( rows, type = 'csv' ) => {
 
     XLSX.writeFile(wb, filename);
 
-  } else {
+  } else if(type == 'pdf'){
+    let data = rowsForExport;
+    const docDefinition = PdfDocDefinition.createDefinition(data);
+    pdfMake.createPdf(docDefinition).print({}, window.open('', '_blank'));
+  }else {
 
     jsonExport(rowsForExport, {headers: ['id', 'title', 'description']}, (err, csv) => {
       downloadCSV(csv, 'ideas');
@@ -165,6 +173,15 @@ export const ListActions = props => {
         resource={resource}
         sort={currentSort}
         label="Export xlsx"
+        filter={{...filterValues, ...permanentFilter}}
+      />
+      <ExportButton
+        exporter={rows => exporter(rows, 'pdf')}
+        disabled={total === 0}
+        maxResults={100000}
+        resource={resource}
+        sort={currentSort}
+        label="Export pdf"
         filter={{...filterValues, ...permanentFilter}}
       />
       <ImportButton resource={resource}/>

--- a/src/resources/idea/list.jsx
+++ b/src/resources/idea/list.jsx
@@ -94,8 +94,7 @@ const exporter = ( rows, type = 'csv' ) => {
     XLSX.writeFile(wb, filename);
 
   } else if(type == 'pdf'){
-    let data = rowsForExport;
-    const docDefinition = PdfDocDefinition.createDefinition(data);
+    const docDefinition = PdfDocDefinition.createDefinition(rowsForExport);
     pdfMake.createPdf(docDefinition).print({}, window.open('', '_blank'));
   }else {
 

--- a/src/resources/idea/pdf-doc-definition.jsx
+++ b/src/resources/idea/pdf-doc-definition.jsx
@@ -30,7 +30,6 @@ export default class PdfDocDefinition {
         };
 
         publishedIdeas.forEach((idea, index) => {
-
             result.content.push(
                 {
                     text: idea.title,
@@ -60,7 +59,6 @@ export default class PdfDocDefinition {
                     .replace(/<br \/>/ig, "")
                     .replace(/<\/div>/ig, "")
                     .replace(/<div>/ig, ""),
-
                     margin: [0,0,0,32],
                 },
                 idea['extraData.theme']? {
@@ -83,7 +81,7 @@ export default class PdfDocDefinition {
 
             Object.keys(idea).filter(key => key.startsWith("extraData") && key !== "extraData.phone" && key !== "extraData.theme" && key !== "extraData.area")
             .forEach(key => {
-                result.content.push(idea[key]? {text: `${key}1: ${idea[key]}`, margin: [0,0,0,4]}: null)
+                result.content.push(idea[key]? {text: `${key}: ${idea[key]}`, margin: [0,0,0,4]}: null)
             });
 
             result.content.push( index < ideas.length -1 ? {

--- a/src/resources/idea/pdf-doc-definition.jsx
+++ b/src/resources/idea/pdf-doc-definition.jsx
@@ -4,7 +4,7 @@ export default class PdfDocDefinition {
 
     static createDefinition(ideas) {
         const images = {};
-        const publishedIdeas = ideas.filter((idea) => idea.publishedDate);
+        const publishedIdeas = ideas.filter((idea) => idea.publishDate);
         
         publishedIdeas.forEach(idea => {
             try {

--- a/src/resources/idea/pdf-doc-definition.jsx
+++ b/src/resources/idea/pdf-doc-definition.jsx
@@ -21,7 +21,7 @@ export default class PdfDocDefinition {
             content: [],
             footer: function(currentPage, pageCount) { 
                 return { 
-                    text: currentPage.toString() + ' of ' + pageCount, 
+                    text: `${currentPage.toString()} van ${pageCount}`, 
                     alignment: 'right', 
                     margin: [0, 0, 32, 0] 
                 }
@@ -30,6 +30,7 @@ export default class PdfDocDefinition {
         };
 
         publishedIdeas.forEach((idea, index) => {
+
             result.content.push(
                 {
                     text: idea.title,
@@ -40,7 +41,6 @@ export default class PdfDocDefinition {
                 images['image'+idea.id]? {
                     image: 'image'+idea.id,
                     width: ((595.28) - 80),
-                    
                     margin: [0,0,0,16],
                 }: null,
                 {
@@ -63,26 +63,33 @@ export default class PdfDocDefinition {
 
                     margin: [0,0,0,32],
                 },
-                {
+                idea['extraData.theme']? {
                     text: `Thema: ${idea['extraData.theme']}`,
                     margin: [0,0,0,4]
-                },
-                {
+                }:null,
+                idea['extraData.area']? {
                     text: `Gebied: ${idea['extraData.area']}`,
                     margin: [0,0,0,4]
-                },
-                {
+                }:null,
+                idea['extraData.phone']? {
                     text: `Telefoonnummer: ${idea['extraData.phone']}`,
                     margin: [0,0,0,4]
-                },
-                {
-                    text: `Email: ${idea['user.email']}`
-                },
-                index < ideas.length -1 ? {
-                    text: '',
-                    pageBreak: 'after'
-                }: null,
+                }:null,
+                idea['user.email']? {
+                    text: `Email: ${idea['user.email']}`,
+                    margin: [0,0,0,16]
+                }:null,
             );
+
+            Object.keys(idea).filter(key => key.startsWith("extraData") && key !== "extraData.phone" && key !== "extraData.theme" && key !== "extraData.area")
+            .forEach(key => {
+                result.content.push(idea[key]? {text: `${key}1: ${idea[key]}`, margin: [0,0,0,4]}: null)
+            });
+
+            result.content.push( index < ideas.length -1 ? {
+                text: '',
+                pageBreak: 'after'
+            }: null);
         });
         return result;
     }

--- a/src/resources/idea/pdf-doc-definition.jsx
+++ b/src/resources/idea/pdf-doc-definition.jsx
@@ -1,5 +1,3 @@
-import { _ } from "core-js";
-
 export default class PdfDocDefinition {
 
     static createDefinition(ideas) {

--- a/src/resources/idea/pdf-doc-definition.jsx
+++ b/src/resources/idea/pdf-doc-definition.jsx
@@ -1,0 +1,89 @@
+import { _ } from "core-js";
+
+export default class PdfDocDefinition {
+
+    static createDefinition(ideas) {
+        const images = {};
+        const publishedIdeas = ideas.filter((idea) => idea.publishedDate);
+        
+        publishedIdeas.forEach(idea => {
+            try {
+                if(idea['extraData.images'] && idea['extraData.images'] !== '[]') {
+                    images['image'+ idea.id] = JSON.parse(idea['extraData.images'])[0];
+                }
+            } catch(e) {
+
+            }
+        });
+        
+        let result = {
+            pageSize: 'A4',
+            content: [],
+            footer: function(currentPage, pageCount) { 
+                return { 
+                    text: currentPage.toString() + ' of ' + pageCount, 
+                    alignment: 'right', 
+                    margin: [0, 0, 32, 0] 
+                }
+            },
+            images
+        };
+
+        publishedIdeas.forEach((idea, index) => {
+            result.content.push(
+                {
+                    text: idea.title,
+                    fontSize: 24,
+                    bold: true,
+                    margin: [0,0,0,16]
+                },
+                images['image'+idea.id]? {
+                    image: 'image'+idea.id,
+                    width: ((595.28) - 80),
+                    
+                    margin: [0,0,0,16],
+                }: null,
+                {
+                    text: `Door: ${idea['user.displayName']}`
+                },
+                {
+                    text: `${idea.startDateHumanized}`,
+                    margin: [0,0,0,16]
+                },
+                {
+                    text: idea.summary,
+                    bold: true,
+                    margin: [0,0,0,4]
+                },
+                {
+                    text: idea.description
+                    .replace(/<br \/>/ig, "")
+                    .replace(/<\/div>/ig, "")
+                    .replace(/<div>/ig, ""),
+
+                    margin: [0,0,0,32],
+                },
+                {
+                    text: `Thema: ${idea['extraData.theme']}`,
+                    margin: [0,0,0,4]
+                },
+                {
+                    text: `Gebied: ${idea['extraData.area']}`,
+                    margin: [0,0,0,4]
+                },
+                {
+                    text: `Telefoonnummer: ${idea['extraData.phone']}`,
+                    margin: [0,0,0,4]
+                },
+                {
+                    text: `Email: ${idea['user.email']}`
+                },
+                index < ideas.length -1 ? {
+                    text: '',
+                    pageBreak: 'after'
+                }: null,
+            );
+        });
+        return result;
+    }
+};


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Added support to print the NON-conceptual plans to pdf
A plan is non-conceptual if the publishedDate is filled

- a list of any dependencies that are required for this change
For pdfs to actually be exported, this pr needs to be approved and merged https://github.com/openstad/openstad-api/pull/252 else an empty pdf will be returned

## Issue reference
https://trello.com/c/KyiKlw3d


## Type of change
Feature

## Tests
Create a few plans through a site where you can create plans. At the bottom of the form you will have two buttons one for saving and one for saving as concept. Create e few plans with both buttons and print the pdf in the admin (beta) page in the section 'plannen'.

## Branch

If the branch to merge to is not development

