### PR TITLE
Move site.config.projectHasEnded to site.config.project.projectHasEnded

### DIFF
--- a/src/resources/site/index.jsx
+++ b/src/resources/site/index.jsx
@@ -84,7 +84,7 @@ const AutomaticallyUpdateStatusInput = ({source, record}) => {
 const ProjectHasEndedInput = ({source, record}) => {
 
   let warningsHTML = null;
-  if (record.config.projectHasEnded) {
+  if (record.config.project.projectHasEnded) {
     let warnings = [];
     if (record.config.votes.isActive !== false) warnings.push( 'votes.isActive is not false' );
     if (record.config.ideas.canAddNewIdeas !== false) warnings.push( 'ideas.canAddNewIdeas is not false' );
@@ -106,7 +106,7 @@ const ProjectHasEndedInput = ({source, record}) => {
       {/* Het wordt tijd voor een taal switch... */}
       <div fullWidth>Setting the 'Project has ended' parameter will automatically update 'Can add new ideas', 'Votes are active', etc.</div>
       {warningsHTML}
-      <BooleanInput source="config.projectHasEnded" label="Project has ended" fullWidth initialValue={false} variant="outlined" />
+      <BooleanInput source="config.project.projectHasEnded" label="Project has ended" fullWidth initialValue={false} variant="outlined" />
     </div>
   );
 
@@ -123,7 +123,7 @@ export const SiteEdit = (props) => {
           <BooleanInput source="config.users.canCreateNewUsers" label="New users can log in?" fullWidth initialValue={true}  variant="outlined" />
           <BooleanInput source="config.users.allowUseOfNicknames" label="Can users create an alias?" fullWidth initialValue={true}  variant="outlined" />
           <BooleanInput source="config.articles.canAddNewArticles" label="Possible to send in articles?" fullWidth initialValue={true}  variant="outlined" />
-          <ProjectHasEndedInput source="config.projectHasEnded"/>
+          <ProjectHasEndedInput source="config.project.projectHasEnded"/>
         </FormTab>
         <FormTab label="Ideas">
           <BooleanInput source="config.ideas.canAddNewIdeas" label="Possible to send in ideas?" fullWidth initialValue={true}  variant="outlined" />


### PR DESCRIPTION
## Description

Anonimize site users contains two main parts:
- make sure that siteadmins or project managers anonymize old sites
- remove users that have been inactive for a certain amount of time

More information can be found in the concurrent API update:
https://github.com/openstad/openstad-api/pull/257

Changes to the react-admin are:
- Move site.config.projectHasEnded to site.config.project.projectHasEnded
